### PR TITLE
Remove 'The' from 'The Scottish Government'

### DIFF
--- a/data/government-organisation/government-organisation.tsv
+++ b/data/government-organisation/government-organisation.tsv
@@ -828,7 +828,7 @@ OT1016	Bank of England	https://www.gov.uk/government/organisations/bank-of-engla
 PB1017	Independent Medical Expert Group	https://www.gov.uk/government/organisations/independent-medical-expert-group		
 OT1018	Mid Staffordshire NHS Foundation Trust Public Inquiry 2010	https://www.gov.uk/government/organisations/mid-staffordshire-nhs-foundation-trust-public-inquiry-2010		2010-02
 DA1019	Welsh Government	https://www.gov.uk/government/organisations/welsh-government		
-DA1020	The Scottish Government	https://www.gov.uk/government/organisations/the-scottish-government		
+DA1020	Scottish Government	https://www.gov.uk/government/organisations/the-scottish-government		
 DA1021	Northern Ireland Executive	https://www.gov.uk/government/organisations/northern-ireland-executive		
 OT1022	UK Co-ordinating Body	https://www.gov.uk/government/organisations/uk-co-ordinating-body		
 OT1023	HM Nautical Almanac Office	https://www.gov.uk/government/organisations/hm-nautical-almanac-office		


### PR DESCRIPTION
This has been discussed with the custodian of local-authority-sct and approved
by the custodian of government-organisation today.