### PR TITLE
Rename DCMS to 'Digital, Culture, Media and Sport'

### DIFF
--- a/data/government-organisation/government-organisation.tsv
+++ b/data/government-organisation/government-organisation.tsv
@@ -3,7 +3,7 @@ D1	Attorney General's Office	https://www.gov.uk/government/organisations/attorne
 D2	Cabinet Office	https://www.gov.uk/government/organisations/cabinet-office		
 D3	Department for Business, Innovation & Skills	https://www.gov.uk/government/organisations/department-for-business-innovation-skills		2016-07-14
 D4	Department for Communities and Local Government	https://www.gov.uk/government/organisations/department-for-communities-and-local-government		
-D5	Department for Culture, Media & Sport	https://www.gov.uk/government/organisations/department-for-culture-media-sport		
+D5	Digital, Culture, Media and Sport	https://www.gov.uk/government/organisations/department-for-culture-media-sport		
 D6	Department for Education	https://www.gov.uk/government/organisations/department-for-education		
 D7	Department for Environment, Food & Rural Affairs	https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs		
 D8	Department for International Development	https://www.gov.uk/government/organisations/department-for-international-development		


### PR DESCRIPTION
The new name was announced on 2017-07-03
https://www.gov.uk/government/news/change-of-name-for-dcms

The custodian notified us today (2017-07-04)

No start-date or end-date is necessary because the department itself is the
same, and has the same unique id.