### PR TITLE
Rename OT488 from NHS Litigation Authority to NHS Resolution

### DIFF
--- a/data/government-organisation/government-organisation.tsv
+++ b/data/government-organisation/government-organisation.tsv
@@ -979,3 +979,4 @@ PB1214	Institute for Apprenticeships	https://www.gov.uk/government/organisations
 OT1215	Judicial Office	https://www.gov.uk/government/organisations/judicial-office		
 EO1216	Education and Skills Funding Agency	https://www.gov.uk/government/organisations/education-and-skills-funding-agency		
 PB1218	Regulator of Social Housing	https://www.gov.uk/government/organisations/regulator-of-social-housing		
+OT488	NHS Resolution	https://www.gov.uk/government/organisations/nhs-litigation-authority		


### PR DESCRIPTION
Per the custodian's request

NHS Litigation Authority was replaced with NHS Resolution in April 2017
(see - http://www.nhsla.com/Pages/Home.aspx)